### PR TITLE
Call stylefmt with its config in configFile instead of config

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postcss-scss": "0.3.1"
   },
   "peerDependencies":{
-    "stylefmt": "4.x",
+    "stylefmt": "5.x",
     "postcss": "5.x"
   },
   "devDependencies": {

--- a/stylefmt-loader.js
+++ b/stylefmt-loader.js
@@ -14,7 +14,7 @@ module.exports = function (source) {
   let query = loaderUtils.parseQuery(this.query);
   
   postcss([stylefmt({
-    config: `${process.cwd()}/${query.config}`
+    configFile: `${process.cwd()}/${query.config}`
   })])
     .process(source, {syntax: scss})
     .then(function (result) {


### PR DESCRIPTION
This fixes https://github.com/tomasAlabes/stylefmt-loader/issues/3.

The problem seems to be that ```stylefmt``` now calls ```stylelint``` in a different way.

https://github.com/morishitter/stylefmt/commit/b68bc3eed52e29ef5e467321b9eca9dd7a1411f7 could be the cause.